### PR TITLE
ci: pin actions to SHA digests and update to Node 24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,56 +9,56 @@ on:
 jobs:
   lint:
     name: Run ESLint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: npm ci
       - run: npm run lint
 
   test:
     name: Run tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: npm ci
       - run: npm test
 
   check-dist:
     name: Check Distribution
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       BUNDLE_FILE: "dist/index.js"
       BUNDLE_COMMAND: "npm run bundle"
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: 16
+          node-version: 24
 
       - name: Install
         run: npm ci
 
       - name: Verify Latest Bundle
-        uses: redhat-actions/common/bundle-verifier@v1
+        uses: redhat-actions/common/bundle-verifier@a7e9fd367034e38805280ad71d9cc35e2d9f6f9d # v1
         with:
           bundle_file: ${{ env.BUNDLE_FILE }}
           bundle_command: ${{ env.BUNDLE_COMMAND }}
 
   check-inputs-outputs:
     name: Check Input and Output enums
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     env:
       IO_FILE: ./src/generated/inputs-outputs.ts
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Install dependencies
         run: npm ci
 
       - name: Verify Input and Output enums
-        uses: redhat-actions/common/action-io-generator@v1
+        uses: redhat-actions/common/action-io-generator@a7e9fd367034e38805280ad71d9cc35e2d9f6f9d # v1
         with:
           io_file: ${{ env.IO_FILE }}

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -12,9 +12,9 @@ on:
 jobs:
   markdown-link-check:
     name: Check links in markdown
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: gaurav-nelson/github-action-markdown-link-check@v1
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: gaurav-nelson/github-action-markdown-link-check@499c1e7f3637c131334fa8e937c45144f79d72d2 # v1
         with:
           use-verbose-mode: true

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -9,19 +9,19 @@ on:
 
 jobs:
   crda-scan:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: Scan project vulnerability with CRDA
     steps:
 
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Setup Node
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
         with:
-          node-version: '16'
+          node-version: '24'
 
       - name: Install CRDA
-        uses: redhat-actions/openshift-tools-installer@v1
+        uses: redhat-actions/openshift-tools-installer@144527c7d98999f2652264c048c7a9bd103f8a82 # v1
         with:
           source: github
           github_pat: ${{ github.token }}
@@ -29,7 +29,7 @@ jobs:
 
       - name: CRDA Scan
         id: scan
-        uses: redhat-actions/crda@v1
+        uses: redhat-actions/crda@6310ee94a6ac8f76b4152b7267c6cd7f1277052c # v1
         with:
           crda_key: ${{ secrets.CRDA_KEY }}
           fail_on: never


### PR DESCRIPTION
## Summary

- Pin all GitHub Actions to SHA digests to prevent supply chain attacks
- Update to Node 24-compatible versions where available
- Bump runner OS from `ubuntu-20.04` to `ubuntu-22.04`
- Update Node version from 16 to 24

| Action | Old | New |
|--------|-----|-----|
| `actions/checkout` | `@v2` | `@v7` (SHA pinned) |
| `actions/setup-node` | `@v2`/`@v3` | `@v6` (SHA pinned) |
| `gaurav-nelson/github-action-markdown-link-check` | `@v1` | SHA pinned |
| `redhat-actions/common/*` | `@v1` | SHA pinned |
| `redhat-actions/openshift-tools-installer` | `@v1` | SHA pinned |
| `redhat-actions/crda` | `@v1` | SHA pinned |

## Test plan

- [ ] CI workflow runs without Node deprecation warnings
- [ ] Lint, test, check-dist, and check-inputs-outputs jobs pass
- [ ] Link checker and security scan jobs pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)