### PR TITLE
ci: add typecheck job and integration test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,15 @@ on:
     - cron: '0 0 * * *'  # every day at midnight
 
 jobs:
+  typecheck:
+    name: Run TypeScript compiler
+    runs-on: ubuntu-22.04
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - run: npm ci
+      - run: npx tsc --noEmit
+
   lint:
     name: Run ESLint
     runs-on: ubuntu-22.04

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,0 +1,19 @@
+name: Integration Test
+on:
+  pull_request_target:
+    types: [ opened, synchronize, reopened ]
+
+jobs:
+  integration-test:
+    runs-on: ubuntu-22.04
+    name: Run action on PR
+
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
+      - name: Try in Web IDE
+        uses: ./
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          add_comment: 'true'
+          add_status: 'true'


### PR DESCRIPTION
## Summary
- Adds a TypeScript compile check (`tsc --noEmit`) job to CI to catch type errors in files without test coverage
- Adds an integration test workflow that runs the action itself on PRs via `pull_request_target`, verifying the bundle loads and posts comments/status checks end-to-end

## Test plan
- [ ] `Run TypeScript compiler` job passes in CI Checks
- [ ] `Integration Test` workflow runs on this PR and posts a "Try in Web IDE" comment and status check

🤖 Generated with [Claude Code](https://claude.com/claude-code)