### PR TITLE
ci: harden workflows with least-privilege permissions and modernize runners

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,44 +6,58 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   typecheck:
     name: Run TypeScript compiler
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: npm ci
       - run: npx tsc --noEmit
 
   lint:
     name: Run ESLint
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: npm ci
       - run: npm run lint
 
   test:
     name: Run tests
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - run: npm ci
       - run: npm test
 
   check-dist:
     name: Check Distribution
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     env:
       BUNDLE_FILE: "dist/index.js"
       BUNDLE_COMMAND: "npm run bundle"
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
-      - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: 24
 
@@ -51,23 +65,25 @@ jobs:
         run: npm ci
 
       - name: Verify Latest Bundle
-        uses: redhat-actions/common/bundle-verifier@a7e9fd367034e38805280ad71d9cc35e2d9f6f9d # v1
+        uses: redhat-actions/common/bundle-verifier@ad38cc90ef0aa8ba71be3efaec1ef60fdf7853b3 # v2
         with:
           bundle_file: ${{ env.BUNDLE_FILE }}
           bundle_command: ${{ env.BUNDLE_COMMAND }}
 
   check-inputs-outputs:
     name: Check Input and Output enums
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     env:
       IO_FILE: ./src/generated/inputs-outputs.ts
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Install dependencies
         run: npm ci
 
       - name: Verify Input and Output enums
-        uses: redhat-actions/common/action-io-generator@a7e9fd367034e38805280ad71d9cc35e2d9f6f9d # v1
+        uses: redhat-actions/common/action-io-generator@ad38cc90ef0aa8ba71be3efaec1ef60fdf7853b3 # v2
         with:
           io_file: ${{ env.IO_FILE }}

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -3,13 +3,25 @@ on:
   pull_request_target:
     types: [ opened, synchronize, reopened ]
 
+# pull_request_target runs with write access on the base branch.
+# Scope permissions to the minimum needed: write PR comments and statuses.
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
 jobs:
   integration-test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Run action on PR
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Try in Web IDE
         uses: ./

--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -9,12 +9,20 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   markdown-link-check:
     name: Check links in markdown
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - uses: gaurav-nelson/github-action-markdown-link-check@499c1e7f3637c131334fa8e937c45144f79d72d2 # v1
         with:
           use-verbose-mode: true

--- a/.github/workflows/security_scan.yml
+++ b/.github/workflows/security_scan.yml
@@ -7,16 +7,24 @@ on:
   schedule:
     - cron: '0 0 * * *'  # every day at midnight
 
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   npm-audit:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     name: Scan project vulnerabilities with npm audit
+    permissions:
+      contents: read
 
     steps:
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Setup Node
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7
         with:
           node-version: '24'
 


### PR DESCRIPTION
## Summary

- Added `permissions: {}` (deny-all default) at workflow level to all 4 CI workflows, with minimal per-job grants
- Scoped `integration_test.yml` (`pull_request_target`) to `contents: read`, `pull-requests: write`, `statuses: write` — previously inherited full write access to the base repo
- Upgraded all runners from `ubuntu-22.04` to `ubuntu-24.04`
- Added `concurrency` groups with `cancel-in-progress: true` to all workflows
- Upgraded `actions/checkout` v7.0.0 → v7.0.1, `actions/setup-node` v6 → v7, `redhat-actions/common` v1 → v2 (all SHA-pinned)

## Test plan

- [x] YAML syntax validated
- [x] All actions SHA-pinned with version comments
- [ ] CI workflows run successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)