### PR TITLE
fix(ci): add issues:write permission to integration test

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -17,6 +17,7 @@ jobs:
     name: Run action on PR
     permissions:
       contents: read
+      issues: write
       pull-requests: write
       statuses: write
 


### PR DESCRIPTION
## Summary

- Added `issues: write` permission to the integration test workflow job
- The GitHub API for creating PR comments uses the issues endpoint (`rest/issues/comments#create-an-issue-comment`), so `pull-requests: write` alone is insufficient
- This was exposed when default workflow permissions were changed to read-only in the security hardening work

**Note:** This needs to be merged before PRs #51 and #52 can pass their integration tests, since `pull_request_target` reads the workflow from the base branch.

## Test plan

- [ ] Integration test passes on subsequent PRs after this is merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)