### PR TITLE
ci: replace archived markdown-link-check with lychee

### DIFF
--- a/.github/workflows/link_check.yml
+++ b/.github/workflows/link_check.yml
@@ -23,6 +23,6 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: gaurav-nelson/github-action-markdown-link-check@499c1e7f3637c131334fa8e937c45144f79d72d2 # v1
+      - uses: lycheeverse/lychee-action@e7477775783ea5526144ba13e8db5eec57747ce8 # v2.9.0
         with:
-          use-verbose-mode: true
+          args: --verbose --no-progress '**/*.md'


### PR DESCRIPTION
## Summary

- Replaced archived `gaurav-nelson/github-action-markdown-link-check` (archived April 2026) with `lycheeverse/lychee-action` v2.9.0
- Lychee is a fast Rust-based link checker with active maintenance
- SHA-pinned to `e7477775783ea5526144ba13e8db5eec57747ce8`

## Test plan

- [ ] Link checker workflow runs successfully on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)