### PR TITLE
chore(deps): update js-yaml to 3.15.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4398,9 +4398,9 @@
             "license": "MIT"
         },
         "node_modules/js-yaml": {
-            "version": "3.15.0",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-            "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+            "version": "3.15.1",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.1.tgz",
+            "integrity": "sha512-S99WuO3HlhO3XN41EtYUNl9zzXjoJx7QvmipxsJVxtCBT0YHEFy+iOJhjSvrmV12nYhWpZaM8lPHkJm0yUMbag==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
## Summary
- Updates transitive dev dependency `js-yaml` from 3.15.0 to 3.15.1
- Fixes [GHSA-5p4m-2wfm-xmqj](https://github.com/redhat-actions/try-in-web-ide/security/dependabot/66) — quadratic CPU consumption in `!!omap` resolution (CVSS 7.5)
- Lockfile-only change; both consumers (`@redhat-actions/action-io-generator` and `@istanbuljs/load-nyc-config`) already accept `^3.x`

## Test plan
- [x] All 32 tests pass locally
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)